### PR TITLE
Add /_status endpoint and readiness checks

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -31,4 +31,8 @@ class Application @Inject() (environment: Environment) extends Controller {
       })
       .getOrElse(NotFound)
   }
+
+  def status = Action {
+    Ok
+  }
 }

--- a/bin/build-local
+++ b/bin/build-local
@@ -10,4 +10,6 @@ sbt assembly
 pushd "$DIR/.."
   docker build -t "nickt/blog-server:$SHA" -f "Dockerfile.server" .
   docker build -t "nickt/blog-nginx:$SHA" -f "Dockerfile.nginx" .
+  docker tag "nickt/blog-server:$SHA" "nickt/blog-server"
+  docker tag "nickt/blog-nginx:$SHA" "nickt/blog-nginx"
 popd

--- a/conf/routes
+++ b/conf/routes
@@ -7,5 +7,8 @@ GET     /              controllers.Application.index
 GET     /til           controllers.Application.tilIndex
 GET     /til/*path     controllers.Application.tilArticle(path: String)
 
+# Status
+GET     /_status       controllers.Application.status
+
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file        controllers.Assets.at(path="/public", file)

--- a/kube/gcp/deployment-canary.yaml
+++ b/kube/gcp/deployment-canary.yaml
@@ -18,12 +18,11 @@ spec:
           - containerPort: 80
         readinessProbe:
           httpGet:
-            path: /til
-            port: 80
-          periodSeconds: 5
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 10
+            httpHeaders:
+              - name: Host
+                value: webserver
+            path: /_status
+            port: 9000
       - name: server
         image: gcr.io/nicktravers-site/server:canary
         imagePullPolicy: Always

--- a/kube/gcp/deployment-prod.yaml
+++ b/kube/gcp/deployment-prod.yaml
@@ -18,12 +18,11 @@ spec:
           - containerPort: 80
         readinessProbe:
           httpGet:
-            path: /til
-            port: 80
-          periodSeconds: 5
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 10
+            httpHeaders:
+              - name: Host
+                value: webserver
+            path: /_status
+            port: 9000
       - name: server
         image: gcr.io/nicktravers-site/server:latest
         imagePullPolicy: Always

--- a/kube/local/deployment.yaml
+++ b/kube/local/deployment.yaml
@@ -12,18 +12,17 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nickt/blog-nginx:6b94e75dec486824b5c8d1e8cf6a09ad61e3e40e
+        image: nickt/blog-nginx:latest
         imagePullPolicy: Never
         ports:
           - containerPort: 80
         readinessProbe:
           httpGet:
-            path: /til
-            port: 80
-          periodSeconds: 5
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 10
+            httpHeaders:
+              - name: Host
+                value: webserver
+            path: /_status
+            port: 9000
       - name: webserver
-        image: nickt/blog-server:6b94e75dec486824b5c8d1e8cf6a09ad61e3e40e
+        image: nickt/blog-server:latest
         imagePullPolicy: Never


### PR DESCRIPTION
Mark the nginx container as ready to serve traffic only when the backend
webserver responds with a status 200 on a /_status endpoint.

This prevents the case where nginx starts up faster than the webserver
(which is usually always the case) and returns 502 until the backend is
ready.

Label containers in development with :latest.