### PR TITLE
Cache requests to webserver backends

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,5 +1,6 @@
 FROM nginx
 
+RUN mkdir -p /data/nginx/cache
 ADD conf/nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 80

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,11 +3,22 @@ events {
 }
 
 http {
+  proxy_cache_path  /data/nginx/cache  levels=1:2  keys_zone=STATIC:10m
+  inactive=60m  max_size=1g  use_temp_path=off;
+
   server {
     listen 80;
 
     location / {
-      proxy_pass http://localhost:9000;
+      proxy_pass   http://localhost:9000;
+
+      proxy_cache        STATIC;
+      proxy_cache_valid  10m;
+    }
+
+    # Don't cache the status endpoint responses
+    location = /_status {
+      proxy_pass   http://localhost:9000;
     }
   }
 }


### PR DESCRIPTION
Minor optimization to allow each pod's nginx server to cache request to
it's backend webserver.

The /_status endpoint is not cached to ensure that an accurate status is
reflected.