### PR TITLE
Set cache content directives

### DIFF
--- a/webserver/src/main/java/com/nickt/blog/webserver/HttpUtils.java
+++ b/webserver/src/main/java/com/nickt/blog/webserver/HttpUtils.java
@@ -1,0 +1,20 @@
+package com.nickt.blog.webserver;
+
+import javax.ws.rs.core.CacheControl;
+
+/**
+ * Static utility methods and constants.
+ */
+class HttpUtils {
+
+  private static final int CACHE_CONTROL_MAX_AGE_SECONDS = 86400; // 1 day
+
+  static CacheControl CACHE_CONTROL = new CacheControl();
+  static {
+    CACHE_CONTROL.setMaxAge(CACHE_CONTROL_MAX_AGE_SECONDS);
+  }
+
+  // Static helper class
+  private HttpUtils() {
+  }
+}

--- a/webserver/src/main/java/com/nickt/blog/webserver/StaticContentServlet.java
+++ b/webserver/src/main/java/com/nickt/blog/webserver/StaticContentServlet.java
@@ -11,11 +11,11 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
 
 /**
  * Handler for static content, served from the {@code /static} path.
  */
-// TODO: Add caching
 @Singleton
 public class StaticContentServlet extends HttpServlet {
 
@@ -43,6 +43,7 @@ public class StaticContentServlet extends HttpServlet {
     }
 
     response.setContentType(mimeMap.getContentType(path));
+    response.setHeader(HttpHeaders.CACHE_CONTROL, HttpUtils.CACHE_CONTROL.toString());
 
     ServletOutputStream outputStream = response.getOutputStream();
     ByteStreams.copy(inputStream, outputStream);

--- a/webserver/src/main/java/com/nickt/blog/webserver/TilHandler.java
+++ b/webserver/src/main/java/com/nickt/blog/webserver/TilHandler.java
@@ -69,6 +69,7 @@ public class TilHandler {
   private static Response okResponse(Object content) {
     return Response
         .status(Response.Status.OK)
+        .cacheControl(HttpUtils.CACHE_CONTROL)
         .entity(content)
         .build();
   }

--- a/webserver/src/main/resources/templates/main.html
+++ b/webserver/src/main/resources/templates/main.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="/static/stylesheets/mono-blue.css">
   <link rel="shortcut icon" type="image/png" href="/static/images/favicon-16x16.png" sizes="16x16" />
   <link rel="shortcut icon" type="image/png" href="/static/images/favicon-32x32.png" sizes="32x32" />
-  <script src="/static/javascripts/jquery-1.9.0.min.js" type="text/javascript"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" type="text/javascript"></script>
   <script src="/static/javascripts/highlight.pack.js" type="text/javascript"></script>
   <script>hljs.initHighlightingOnLoad();</script>
 </head>


### PR DESCRIPTION
All content is currently static, and can be cached. Set caching
directives in webserver, and serve minified javascript from Cloudflare,
where available.