### PR TITLE
Vary cache-control max-age based on content type

### DIFF
--- a/webserver/src/main/java/com/nickt/blog/webserver/HttpUtils.java
+++ b/webserver/src/main/java/com/nickt/blog/webserver/HttpUtils.java
@@ -1,5 +1,6 @@
 package com.nickt.blog.webserver;
 
+import java.util.concurrent.TimeUnit;
 import javax.ws.rs.core.CacheControl;
 
 /**
@@ -7,11 +8,14 @@ import javax.ws.rs.core.CacheControl;
  */
 class HttpUtils {
 
-  private static final int CACHE_CONTROL_MAX_AGE_SECONDS = 86400; // 1 day
+  /**
+   * Returns a {@link CacheControl} for the given {@code maxAge}.
+   */
+  static CacheControl cacheControlMaxAge(long maxAge, TimeUnit timeUnit) {
+    CacheControl cacheControl = new CacheControl();
+    cacheControl.setMaxAge(Math.toIntExact(timeUnit.toSeconds(maxAge)));
 
-  static CacheControl CACHE_CONTROL = new CacheControl();
-  static {
-    CACHE_CONTROL.setMaxAge(CACHE_CONTROL_MAX_AGE_SECONDS);
+    return cacheControl;
   }
 
   // Static helper class

--- a/webserver/src/main/java/com/nickt/blog/webserver/StaticContentServlet.java
+++ b/webserver/src/main/java/com/nickt/blog/webserver/StaticContentServlet.java
@@ -4,6 +4,7 @@ import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import javax.activation.FileTypeMap;
 import javax.activation.MimetypesFileTypeMap;
@@ -12,6 +13,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.HttpHeaders;
 
 /**
@@ -23,6 +25,7 @@ public class StaticContentServlet extends HttpServlet {
   private static final String MIME_TYPES_PATH = "/mime.types";
   private static final String STATIC_PATH = "/static";
   private static final String GZIP = "gzip";
+  private static final CacheControl CACHE_CONTROL = HttpUtils.cacheControlMaxAge(7, TimeUnit.DAYS);
 
   private final FileTypeMap mimeMap;
 
@@ -45,7 +48,7 @@ public class StaticContentServlet extends HttpServlet {
     }
 
     response.setContentType(mimeMap.getContentType(path));
-    response.setHeader(HttpHeaders.CACHE_CONTROL, HttpUtils.CACHE_CONTROL.toString());
+    response.setHeader(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL.toString());
 
     OutputStream responseStream = response.getOutputStream();
 

--- a/webserver/src/main/java/com/nickt/blog/webserver/TilHandler.java
+++ b/webserver/src/main/java/com/nickt/blog/webserver/TilHandler.java
@@ -7,12 +7,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.Response;
 
 /**
@@ -24,6 +26,7 @@ public class TilHandler {
 
   private static final String TEMPLATE = "main.html";
   private static final String PATH_PREFIX = "/pages/til";
+  private static final CacheControl CACHE_CONTROL = HttpUtils.cacheControlMaxAge(1, TimeUnit.DAYS);
 
   private final Mustache template;
 
@@ -69,7 +72,7 @@ public class TilHandler {
   private static Response okResponse(Object content) {
     return Response
         .status(Response.Status.OK)
-        .cacheControl(HttpUtils.CACHE_CONTROL)
+        .cacheControl(CACHE_CONTROL)
         .entity(content)
         .build();
   }


### PR DESCRIPTION
Static, non-HTML content can be cached for longer than HTML content.

Refactor HttpUtils to allow for a CacheControl to be returned with a
specific max-age, rather than being pinned to 24 hours.