### PR TITLE
Declare maxUnavailable nodes

### DIFF
--- a/kube/gcp/deployment-prod.yaml
+++ b/kube/gcp/deployment-prod.yaml
@@ -4,6 +4,10 @@ metadata:
   name: deployment-blog-prod
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/kube/gcp/deployment-stage.yaml
+++ b/kube/gcp/deployment-stage.yaml
@@ -4,6 +4,10 @@ metadata:
   name: deployment-blog-stage
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Ensure that rolling updates do not leave a deployment in a state where
there are no nodes available to serve traffic.