### PR TITLE
Use 8 core build instances

### DIFF
--- a/kube/gcp/production/cloudbuild.yaml
+++ b/kube/gcp/production/cloudbuild.yaml
@@ -27,4 +27,5 @@ images: [
   'gcr.io/$PROJECT_ID/nginx:latest'
   ]
 
-timeout: 1200s
+options:
+ machineType: 'N1_HIGHCPU_8'

--- a/kube/gcp/staging/cloudbuild.yaml
+++ b/kube/gcp/staging/cloudbuild.yaml
@@ -27,4 +27,5 @@ images: [
   'gcr.io/$PROJECT_ID/nginx:stage'
   ]
 
-timeout: 1200s
+options:
+ machineType: 'N1_HIGHCPU_8'


### PR DESCRIPTION
This speeds up the build time significantly, as the default is to use a
single core VM.

Remove the build timeout override.