### PR TITLE
Set affinity for webserver pods

### DIFF
--- a/kube/gcp/production/webserver.yaml
+++ b/kube/gcp/production/webserver.yaml
@@ -52,6 +52,18 @@ spec:
         - name: tls
           secret:
             secretName: tls-site
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - blog
 ---
 apiVersion: v1
 kind: Service

--- a/kube/gcp/staging/webserver.yaml
+++ b/kube/gcp/staging/webserver.yaml
@@ -52,6 +52,18 @@ spec:
         - name: tls
           secret:
             secretName: tls-site
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - blog
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
To ensure that the webserver pods aren't scheduled on the same nodes,
set a pod anti-affinity, with selection on app=blog.