### PR TITLE
Update cert-manager

### DIFF
--- a/helm/templates/certificate.yaml
+++ b/helm/templates/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ include "blog.fullname" . }}
@@ -12,9 +12,3 @@ spec:
   commonName: {{ .Values.certificate.host }}
   dnsNames:
   - {{ .Values.certificate.host }}
-  acme:
-    config:
-    - dns01:
-        provider: clouddns
-      domains:
-      - {{ .Values.certificate.host }}

--- a/helm/templates/cluster-issuer.yaml
+++ b/helm/templates/cluster-issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: {{ include "blog.fullname" . }}
@@ -10,9 +10,8 @@ spec:
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: issuer-account-key
-    dns01:
-      providers:
-      - name: clouddns
+    solvers:
+    - dns01:
         clouddns:
           project : {{ .Values.clusterIssuer.project }}
           serviceAccountSecretRef:


### PR DESCRIPTION
Update cert-manager to v0.11.0, with associated CRD changes.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>