### PR TITLE
Use Terraform for provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 webserver/target
 content/_site
-
+.terraform/

--- a/README.md
+++ b/README.md
@@ -143,20 +143,6 @@ $ kubectl create secret generic dns \
 $ kubectl describe secret dns --namespace cert-manager
 ```
 
-Create a persistent volume for the certificates:
-
-```
-$ gcloud compute disks create kube-cert-manager --size 10GB
-```
-
-Create a Diffie-Hellman group to use, and upload as a secret:
-
-```
-$ sudo openssl dhparam -out dhparam.pem 2048
-$ kubectl create secret generic tls-dhparam --from-file=dhparam.pem
-$ rm dhparam.pem
-```
-
 Deploy Helm chart:
 
 ```

--- a/bin/init_cluster.sh
+++ b/bin/init_cluster.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# init_cluster.sh - bootstraps a K8s cluster.
+#
+# Installs:
+# - Helm / Tiller
+# - Secret containing a service-account key for interacting with CloudDNS
+# - cert-manager for provisioning TLS certificates using Let's Encrypt
+#
+# Usage: init_cluster.sh ENV
+#
+# ENV: one of 'staging' or 'production'
+#
+
+set -eo pipefail
+
+CERT_MANAGER_VERSION=0.11
+
+if [[ -z "$1" ]]; then
+  echo "Usage: init_cluster.sh ENV"
+  exit 1
+fi
+
+set -u
+
+env="$1"
+
+helm delete cert-manager --purge || true
+echo "Installing Helm"
+_helm_install=/volumes/secure/helm.yaml
+cat << HERE > "$_helm_install"
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  # Use the pre-existing cluster role that comes with GKE.
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system
+HERE
+kubectl apply -f "$_helm_install"
+helm reset --force || true
+helm init --service-account tiller
+
+until kubectl -n kube-system get pod -l name=tiller -o jsonpath='{.items[].status.phase}' | grep -q Running; do
+  echo "Waiting for Tiller ..."
+  sleep 1
+done
+
+echo "Deleting all existing keys from the service-accont"
+_keys=$(gcloud iam service-accounts keys list \
+  --iam-account "cert-manager-$env@nicktravers-site.iam.gserviceaccount.com" \
+  --managed-by=user \
+  | tail -n+2 \
+  | awk '{print $1}')
+
+for _key in $_keys; do
+  echo "Deleting key: $_key"
+  gcloud iam service-accounts keys delete "$_key" \
+    --iam-account "cert-manager-$env@nicktravers-site.iam.gserviceaccount.com" \
+    --quiet
+done
+
+echo "Creating service-account key"
+_key_file=/volumes/secure/service-account.json
+gcloud iam service-accounts keys create "$_key_file" \
+  --iam-account "cert-manager-$env@nicktravers-site.iam.gserviceaccount.com"
+
+echo "Creating cert-manager namespace"
+kubectl delete namespace cert-manager --ignore-not-found=true
+kubectl create namespace cert-manager
+
+echo "Creating Secret for cert-manager DNS permissions"
+kubectl -n cert-manager delete secret dns --ignore-not-found=true
+kubectl -n cert-manager create secret generic dns --from-file "$_key_file"
+
+echo "Setting up cert-manager"
+kubectl apply \
+  --validate=false \
+  -f "https://raw.githubusercontent.com/jetstack/cert-manager/release-$CERT_MANAGER_VERSION/deploy/manifests/00-crds.yaml"
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm install \
+  --name cert-manager \
+  --namespace cert-manager \
+  --version "v$CERT_MANAGER_VERSION" \
+  jetstack/cert-manager
+
+while [[ $(kubectl -n cert-manager get pods \
+  --field-selector=status.phase=Running \
+  --no-headers -o json \
+  | jq .items[].metadata.name | wc -l) -ne 3 ]]; do
+  echo "Waiting for cert-manager ..."
+  sleep 1
+done
+
+echo "Completed cluster setup!"

--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -5,7 +5,7 @@ certificate:
   host: stage.nicktrave.rs
 
 ingress:
-  staticIP: site-staging
+  staticIP: site-ingress-staging
   host: stage.nicktrave.rs
   tls:
     secret: tls-site

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,7 +18,7 @@ certificate:
   host: nicktrave.rs
 
 ingress:
-  staticIP: site-production
+  staticIP: site-ingress-production
   host: nicktrave.rs
   tls:
     secret: tls-site

--- a/terraform/environments/production/backend.tf
+++ b/terraform/environments/production/backend.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = "0.12.10"
+  backend "gcs" {
+    bucket = "nicktravers-site-tf-state-production"
+    prefix = "terraform/state"
+  }
+}
+
+provider "google" {
+  project = "nicktravers-site"
+  version = "2.20.0"
+}

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -1,0 +1,22 @@
+module "network" {
+  source = "../../modules/network"
+
+  name = "production"
+}
+
+module "k8s" {
+  source = "../../modules/kubernetes"
+
+  name              = "production"
+  network           = module.network.network
+  master-version    = "1.14.8-gke.12"
+  node-pool-version = "1.14.8-gke.12"
+  node-count        = "1"
+}
+
+module "services" {
+  source = "../../services"
+
+  name-suffix   = "production"
+  site-dns-name = "nicktrave.rs."
+}

--- a/terraform/environments/staging/backend.tf
+++ b/terraform/environments/staging/backend.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = "0.12.10"
+  backend "gcs" {
+    bucket = "nicktravers-site-tf-state-staging"
+    prefix = "terraform/state"
+  }
+}
+
+provider "google" {
+  project = "nicktravers-site"
+  version = "2.20.0"
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,0 +1,22 @@
+module "network" {
+  source = "../../modules/network"
+
+  name = "staging"
+}
+
+module "k8s" {
+  source = "../../modules/kubernetes"
+
+  name              = "staging"
+  network           = module.network.network
+  master-version    = "1.14.8-gke.12"
+  node-pool-version = "1.14.8-gke.12"
+  node-count        = "0"
+}
+
+module "services" {
+  source = "../../services"
+
+  name-suffix   = "staging"
+  site-dns-name = "stage.nicktrave.rs."
+}

--- a/terraform/modules/ingress/main.tf
+++ b/terraform/modules/ingress/main.tf
@@ -1,0 +1,15 @@
+resource "google_compute_global_address" "ingress" {
+  name = "site-ingress-${var.name-suffix}"
+}
+
+data "google_dns_managed_zone" "site" {
+  name = "site"
+}
+
+resource "google_dns_record_set" "ingress" {
+  managed_zone = data.google_dns_managed_zone.site.name
+  name         = var.dns-name
+  type         = "A"
+  rrdatas      = [google_compute_global_address.ingress.address]
+  ttl          = 60
+}

--- a/terraform/modules/ingress/variables.tf
+++ b/terraform/modules/ingress/variables.tf
@@ -1,0 +1,7 @@
+variable "name-suffix" {
+  description = "The suffix to append to the service account name"
+}
+
+variable "dns-name" {
+  description = "The DNS A record name"
+}

--- a/terraform/modules/kubernetes/main.tf
+++ b/terraform/modules/kubernetes/main.tf
@@ -1,0 +1,76 @@
+resource "google_compute_subnetwork" "k8s-cluster-uc1" {
+  name = "kubenetes-uc1-${var.name}"
+
+  network = var.network
+  region  = "us-central1"
+
+  ip_cidr_range = "10.4.0.0/22" # K8s nodes range
+
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = "10.0.0.0/14"
+  }
+
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = "10.4.4.0/22"
+  }
+
+  private_ip_google_access = true
+}
+
+resource "google_container_cluster" "uc1" {
+  name = format("%s-uc1", var.name)
+
+  network            = var.network
+  subnetwork         = google_compute_subnetwork.k8s-cluster-uc1.self_link
+  location           = "us-central1"
+  node_locations     = ["us-central1-a", "us-central1-b"]
+  min_master_version = var.master-version
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "pods"
+    services_secondary_range_name = "services"
+  }
+
+  network_policy {
+    provider = "CALICO"
+    enabled  = true
+  }
+
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+}
+
+resource "google_container_node_pool" "preemptible" {
+  name    = "preemptible"
+  cluster = google_container_cluster.uc1.name
+
+  location   = "us-central1"
+  version    = var.node-pool-version
+  node_count = var.node-count
+
+  node_config {
+    preemptible  = true
+    machine_type = "n1-standard-1"
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+
+  management {
+    auto_upgrade = false
+    auto_repair  = true
+  }
+}

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "Name of the kubernetes cluster"
+}
+
+variable "network" {
+  description = "The network the cluster resides in"
+}
+
+variable "node-count" {
+  description = "The number of nodes in the cluster, per zone"
+  default     = 0
+}
+
+variable "master-version" {
+  description = "The version of the K8s master"
+}
+
+variable "node-pool-version" {
+  description = "The version of the nodes in the K8s node pool"
+}

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -1,0 +1,6 @@
+resource "google_compute_network" "network" {
+  name = var.name
+
+  routing_mode            = "GLOBAL"
+  auto_create_subnetworks = false
+}

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -1,0 +1,3 @@
+output "network" {
+  value = google_compute_network.network.self_link
+}

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -1,0 +1,3 @@
+variable "name" {
+  description = "Name of the VPC"
+}

--- a/terraform/services/blog/main.tf
+++ b/terraform/services/blog/main.tf
@@ -1,0 +1,6 @@
+module "ingress" {
+  source = "../../modules/ingress"
+
+  name-suffix = var.name-suffix
+  dns-name    = var.site-dns-name
+}

--- a/terraform/services/blog/variables.tf
+++ b/terraform/services/blog/variables.tf
@@ -1,0 +1,7 @@
+variable "name-suffix" {
+  description = "The suffix to append to ingress resources"
+}
+
+variable "site-dns-name" {
+  description = "The name of the DNS record for the site"
+}

--- a/terraform/services/cert-manager/main.tf
+++ b/terraform/services/cert-manager/main.tf
@@ -1,0 +1,10 @@
+resource "google_service_account" "cert-manager" {
+  account_id   = "cert-manager-${var.name-suffix}"
+  display_name = "cert-manager-${var.name-suffix}"
+  description  = "Allows the altering of CloudDNS records"
+}
+
+resource "google_project_iam_member" "dns-admin" {
+  role   = "roles/dns.admin"
+  member = "serviceAccount:${google_service_account.cert-manager.email}"
+}

--- a/terraform/services/cert-manager/variables.tf
+++ b/terraform/services/cert-manager/variables.tf
@@ -1,0 +1,3 @@
+variable "name-suffix" {
+  description = "The suffix to append to the service account name"
+}

--- a/terraform/services/main.tf
+++ b/terraform/services/main.tf
@@ -1,0 +1,12 @@
+module "cert-manager" {
+  source = "./cert-manager"
+
+  name-suffix = var.name-suffix
+}
+
+module "site" {
+  source = "./blog"
+
+  name-suffix   = var.name-suffix
+  site-dns-name = var.site-dns-name
+}

--- a/terraform/services/variables.tf
+++ b/terraform/services/variables.tf
@@ -1,0 +1,7 @@
+variable "name-suffix" {
+  description = "The suffix to append to the resources"
+}
+
+variable "site-dns-name" {
+  description = "The name of the DNS record for the site"
+}


### PR DESCRIPTION
Make use of Terraform for the provisioning of base infrastructure:
- VPC network
- Subnet for K8s cluster
- K8s cluster and node pool
- Static IP for use with Ingress controller
- DNS A records
- Service accounts and bindings for CloudDNS admin

Add an init_cluster.sh script to assist in bootstrapping a cluster for
the first time.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>