### PR TITLE
Remove Google Cloud DNS record

### DIFF
--- a/terraform/modules/ingress/main.tf
+++ b/terraform/modules/ingress/main.tf
@@ -1,15 +1,3 @@
 resource "google_compute_global_address" "ingress" {
   name = "site-ingress-${var.name-suffix}"
 }
-
-data "google_dns_managed_zone" "site" {
-  name = "site"
-}
-
-resource "google_dns_record_set" "ingress" {
-  managed_zone = data.google_dns_managed_zone.site.name
-  name         = var.dns-name
-  type         = "A"
-  rrdatas      = [google_compute_global_address.ingress.address]
-  ttl          = 60
-}


### PR DESCRIPTION
The domain has been transferred to Cloudflare.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>