### PR TITLE
ci: pin setup-gcloud version; update versions

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -18,7 +18,7 @@ jobs:
         GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
       run: docker tag site gcr.io/$GCP_PROJECT_ID/site:$(git rev-parse HEAD)
     - name: Set up gcloud
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0.6.0
       with:
         version: '290.0.1'
         service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY_PRODUCTION }}

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -2,7 +2,9 @@ name: Staging release
 
 on:
   push:
-    branches: main
+    branches:
+    - main
+    - staging
 
 jobs:
 
@@ -18,7 +20,7 @@ jobs:
         GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
       run: docker tag site gcr.io/$GCP_PROJECT_ID/site:staging
     - name: Set up gcloud
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0.6.0
       with:
         version: '290.0.1'
         service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY_STAGING }}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ A deploy can be initiated manually with the following:
 View actions [here](https://github.com/nicktrav/blog/actions?query=workflow%3A%22Staging+release%22).
 
 ```bash
-GCP_KEY_FILE=/path/to/service/account/key.json
+$ export GCP_PROJECT_ID=...
+$ export=DIGITAL_OCEAN_TOKEN=...
 $ ./deploy/deploy.sh staging staging
 ```
 

--- a/deploy/Dockerfile-deploy
+++ b/deploy/Dockerfile-deploy
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-marketplace-containers/google/debian10@sha256:54e0e8e69dd42cb76c3737c8f44c88bf5ad4ecd187aa6412ad08778254353988 AS build
+FROM gcr.io/cloud-marketplace-containers/google/debian10@sha256:9a4a8331d0626e2b56ababd7e4467b8847ef54809d27e721fba2b4b03073ad02 AS build
 
 RUN apt-get update && \
   apt-get install -y apt-transport-https ca-certificates curl gnupg && \
@@ -22,8 +22,8 @@ RUN apt-get update && \
   apt-get install -y jq && \
   \
 # Digital Ocean utils
-  curl -LO https://github.com/digitalocean/doctl/releases/download/v1.62.0/doctl-1.62.0-linux-amd64.tar.gz && \
-    tar xzf doctl-1.62.0-linux-amd64.tar.gz && \
+  curl -LO https://github.com/digitalocean/doctl/releases/download/v1.77.0/doctl-1.77.0-linux-amd64.tar.gz && \
+    tar xzf doctl-1.77.0-linux-amd64.tar.gz && \
     mv doctl /usr/local/bin/ && \
   \
 # Cleanup


### PR DESCRIPTION
Fix the build by pinning the GitHub action runner version.

Update the Debian container version and Digital Ocean utils.